### PR TITLE
Make Homebrew install command one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ The official command-line tool to interact with [Airbrake.io](https://airbrake.i
 ### Homebrew (MacOS)
 
 ```
-brew tap airbrake/airbrake-cli
-brew install airbrake
+brew install airbrake/airbrake-cli/airbrake
 airbrake --version
 ```
 


### PR DESCRIPTION

This command:
```
brew install airbrake/airbrake-cli/airbrake
```

Is equivalent to this:

```
brew tap airbrake/airbrake-cli
brew install airbrake
```

The benefit is the one line is compact, easier to copy and paste, etc.